### PR TITLE
Fix ubuntu tests to use latest image

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -145,7 +145,7 @@ stages:
     parameters:
       jobName: TestPkgUbuntu16
       displayName: PowerShell Core on Ubuntu 16.04
-      imageName: ubuntu-16.04
+      imageName: ubuntu-latest
 
   - template: test.yml
     parameters:


### PR DESCRIPTION
Current image version is being deprecated, so now using 'latest'.