### PR TITLE
Add aliases that Start-Job has

### DIFF
--- a/src/code/Microsoft.PowerShell.ThreadJob.cs
+++ b/src/code/Microsoft.PowerShell.ThreadJob.cs
@@ -36,6 +36,7 @@ namespace Microsoft.PowerShell.ThreadJob
         private const string FilePathParameterSet = "FilePath";
 
         [Parameter(ParameterSetName = ScriptBlockParameterSet, Mandatory=true, Position=0)]
+        [Alias("Command")]
         [ValidateNotNullAttribute]
         public ScriptBlock ScriptBlock { get; set; }
 
@@ -60,6 +61,7 @@ namespace Microsoft.PowerShell.ThreadJob
 
         [Parameter(ParameterSetName = ScriptBlockParameterSet)]
         [Parameter(ParameterSetName = FilePathParameterSet)]
+        [Alias("Args")]
         public Object[] ArgumentList { get; set; }
 
         [Parameter(ParameterSetName = ScriptBlockParameterSet)]


### PR DESCRIPTION
# PR Summary

Start-Job has a couple aliases that are missing from Start-ThreadJob.

`-ScriptBlock` receives the `-Command` alias
`-ArgumentList` receives the `-Args` alias

Note that, in particular, the `-Args` alias is present in almost every built-in function that has an `-ArgumentList` parameter.

## PR Context

Consistency.