### PR TITLE
Update README link to point to Microsoft.PowerShell.ThreadJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ TotalSeconds
 
 ## Installing
 
-You can install this module from [PowerShell Gallery](https://www.powershellgallery.com/packages/ThreadJob/1.1.2) using this command:
+You can install this module from [PowerShell Gallery](https://www.powershellgallery.com/packages/Microsoft.PowerShell.ThreadJob) using this command:
 
 ```powershell
-Install-Module -Name ThreadJob -Scope CurrentUser
+Install-Module -Name Microsoft.PowerShell.ThreadJob -Scope CurrentUser
 ```
 
 ## Code of Conduct


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request updates the installation instructions in the `README.md` to reference the correct PowerShell Gallery package for the module.

- Documentation update:
  * Changed the PowerShell Gallery link and installation command to use the correct `Microsoft.PowerShell.ThreadJob` package instead of the outdated `ThreadJob` package.

## PR Context

Fixes: #16 
